### PR TITLE
add g29 support

### DIFF
--- a/WheelSupports.cpp
+++ b/WheelSupports.cpp
@@ -91,6 +91,9 @@ bool ConfigDevice(IOHIDDeviceRef hidDevice, DeviceID deviceID, const DeviceMode 
 		case kGPLogitechG27Native:
             printf("Logitech G27 Native mode enabled.\n");
             return ConfigLogitechWheels(hidDevice, deviceID, true, mode);
+		case kGPLogitechG29Native:
+            printf("Logitech G29 Native mode enabled.\n");
+            return ConfigLogitechWheels(hidDevice, deviceID, true, mode);
 		case kGPLogitechDFGTNative:
             printf("Logitech Driving Force GT Native mode enabled.\n");
             return ConfigLogitechWheels(hidDevice, deviceID, true, mode);
@@ -222,6 +225,11 @@ bool ConfigLogitechWheels(IOHIDDeviceRef hidDevice, DeviceID deviceID, bool nati
 			targetDeviceID = kGPLogitechG27Native;
             printf("Logitech G27 Native mode enabled.\n");
 		}
+		else if(CFStringFind(productID, CFSTR(kGPLogitechG29ProductID), 0).location == 0)
+		{
+			targetDeviceID = kGPLogitechG29Native;
+            printf("Logitech G29 Native mode enabled.\n");
+		}
 		else if(CFStringFind(productID, CFSTR(kGPLogitechDFGTProductID), 0).location == 0)
 		{
 			targetDeviceID = kGPLogitechDFGTNative;
@@ -308,6 +316,7 @@ void GetCmdLogitechWheelNative(CCommands *c, const DeviceID deviceID)
 			c->count = 1;
 			break;
 		case kGPLogitechG27Native:
+		case kGPLogitechG29Native:
 
 
             // Original commands
@@ -399,6 +408,7 @@ void GetCmdLogitechWheelRange(CCommands *c, const DeviceID deviceID, int range)
 	switch (deviceID) {
 		case kGPLogitechG25Native:
 		case kGPLogitechG27Native:
+		case kGPLogitechG29Native:
 		case kGPLogitechDFGTNative:
 		{
 			c->cmds[0][0] = 0xf8;

--- a/WheelSupports.h
+++ b/WheelSupports.h
@@ -29,6 +29,7 @@
 #define kGPLogitechWheelRestricted					0xc294046d
 #define kGPLogitechG25Native						0xc299046d
 #define kGPLogitechG27Native						0xc29b046d
+#define kGPLogitechG29Native						0xc24f046d
 #define kGPLogitechDFGTNative						0xc29a046d
 #define kGPLogitechDFPNative						0xc298046d
 #define kGPLogitechG920Native						0xc261046d
@@ -36,6 +37,7 @@
 // Product IDs
 #define kGPLogitechG25ProductID						"G25"
 #define kGPLogitechG27ProductID						"G27"
+#define kGPLogitechG29ProductID                     "G29"
 #define kGPLogitechDFGTProductID					"Driving Force GT"
 #define kGPLogitechDFPProductID						"Driving Force Pro"
 #define kGPLogitechG920ProductID					"G920"


### PR DESCRIPTION
Add g29 support refer to the config of g27  

Tested with Euro Truck Simulator 2 on macOS Sierra 10.12.6

Resolves #1 